### PR TITLE
ci(security): set default workflow permissions to read-all

### DIFF
--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -10,10 +10,13 @@ on:
   repository_dispatch:
     types: [ sync-api ]
 
+permissions: read-all
+
 jobs:
   sync:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: write
     steps:
       - name: Checkout API repository
         uses: actions/checkout@v4


### PR DESCRIPTION
The sync workflow should explicitly define the permissions write on contents

Closes #8 